### PR TITLE
Add simple Dockerfile to run fritzbox_exporter as docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.8-alpine
+
+ADD . $GOPATH/src/github.com/ndecker/fritzbox_exporter
+
+RUN apk add --no-cache git
+RUN go get -v github.com/ndecker/fritzbox_exporter
+
+EXPOSE 9133
+
+ENTRYPOINT ["fritzbox_exporter"]
+CMD [""]
+


### PR DESCRIPTION
This file can be used to do an automatic docker build on hub.docker.com.
An example can be found here: https://hub.docker.com/r/bachp/fritzbox_exporter/