### PR TITLE
Report ListenAndServe errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"sync"
 	"time"
+	"log"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -323,5 +324,5 @@ func main() {
 	prometheus.MustRegister(collect_errors)
 
 	http.Handle("/metrics", prometheus.Handler())
-	http.ListenAndServe(*flag_addr, nil)
+	log.Fatal(http.ListenAndServe(*flag_addr, nil))
 }


### PR DESCRIPTION
Thanks for this nice package!

Report Errors:

```
→ fritzbox_exporter -listen-address :80
2017/04/23 12:39:01 listen tcp :80: bind: permission denied
```

instead of just exiting with *0* (signifying success)


