### PR TITLE
Implement basic auth for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Usage:
         	The address to listen on for HTTP requests. (default ":9133")
       -test
         	print all available metrics to stdout
+      -username
+            The username for requests to the FRITZ!Box UPnP service
+      -password
+            The password for requests to the FRITZ!Box UPnP service
 
 ## Exported metrics
 


### PR DESCRIPTION
This implements basic auth support for requests to the
fritz box. This is the groundwork for supporting some more
metrics via the tr064 api.

With this, support for the tr064 api should be very easy to implement.   
All that's left is to also parse the `tr64desc.xml` (same format as the `igddesc.xml` ) and choose which values to add as metrics.