### PR TITLE
Add another tested FRITZ!Box version to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This exporter exports some variables from an
 [AVM Fritzbox](http://avm.de/produkte/fritzbox/)
 to prometheus.
 
-This exporter is tested with a Fritzbox 7490 and 7390 with software version 06.51.
+This exporter is tested with a Fritzbox 7490 and 7390 with software version 06.51 and a FRITZ!Box 7362 SL with software version 7.12.
 
 ## Building
 


### PR DESCRIPTION
I successfully verified correctness of the application on the FRITZ!Box 7362 SL with firmware version 7.12.