### PR TITLE
Add creation of release including binaries and docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      snapshot:
+        description: 'Run as snapshot'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.19' #in contrast to the go version in go.mod, but url.JoinPath is not available in go 1.18. Probably go.mod needs to be updated
+          cache: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean ${{ github.event.inputs.snapshot == 'true' && '--snapshot' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 fritzbox_exporter
+*.exe

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,73 @@
+# .goreleaser.yaml
+# Documentation at https://goreleaser.com
+version: 2
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+
+builds:
+  - id: fritzbox_exporter_binary
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
+
+archives:
+  - formats:
+      - tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+dockers_v2:
+  - images:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/fritzbox_exporter"
+    tags:
+      - "v{{ .Version }}"
+      - "latest"
+    dockerfile: Dockerfile.release
+    ids:
+      - fritzbox_exporter_binary
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/arm/v7
+      - linux/arm/v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to fritzbox_exporter
+
+## Development
+
+### Building with Go
+
+To build the project locally using Go:
+
+```bash
+go build
+```
+
+### Building with Docker
+
+To build the project locally using Docker
+
+```bash
+docker build -t fritzbox_exporter .
+docker run -p 9133:9133 fritzbox_exporter
+```
+
+## Releases
+
+This project uses [GoReleaser](https://goreleaser.com/) and GitHub Actions to automate the release process of binaries and Docker images.
+
+### How to trigger a new release
+
+Releases are triggered by pushing a new Git tag. 
+
+1. **Check your current version**:
+   Ensure you are on the `main` branch and have the latest changes.
+
+2. **Create a new tag**:
+   Tags should follow semantic versioning (e.g., `v1.0.0`).
+   ```bash
+   git tag -a v1.2.3 -m "Release description"
+   ```
+
+3. **Push the tag**:
+   Pushing the tag to GitHub will trigger the `Release` workflow.
+   ```bash
+   git push origin v1.2.3
+   ```

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,5 @@
+FROM busybox
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/fritzbox_exporter /app/fritzbox_exporter
+EXPOSE 9133
+ENTRYPOINT ["/app/fritzbox_exporter"]


### PR DESCRIPTION
I think it's more convenient for users, if per-build binaires and images exist. So I added goreleaser to add these. A release is automatically created when a v* tag is created.